### PR TITLE
Fixing nginx grammar and receiver to handle Lua code correctly

### DIFF
--- a/lib/Pegex/Nginx.pm
+++ b/lib/Pegex/Nginx.pm
@@ -9,11 +9,12 @@ use Pegex::Nginx::Grammar;
 use Pegex::Nginx::Data;
 
 sub load {
-  my ($self, $in) = @_;
+  my ($self, $in, %args) = @_;
   Pegex::Parser->new(
     grammar  => Pegex::Nginx::Grammar->new,
     receiver => Pegex::Nginx::Data->new,
     #debug => 1,
+    %args
   )->parse($in);
 }
 

--- a/lib/Pegex/Nginx/Data.pm
+++ b/lib/Pegex/Nginx/Data.pm
@@ -3,9 +3,43 @@ use Pegex::Base;
 extends 'Pegex::Tree';
 
 use Data::Dumper;
+use XXX;
 use feature 'say';
 
-sub got_block { 
-  +{ map ref $_ eq 'Pegex::Nginx::Data' ? $_[1]->[0]->[0] : $_, @_ }
+sub got_comment { return; }
+sub got_blank_line { return; }
+
+sub got_assignment {
+    my $self = shift;
+    YYY { assignment => \@_ };
+    return @_;
 }
+
+sub got_lua_word {
+    my $self = shift;
+    YYY {lua_word => \@_};
+    return;
+}
+
+sub got_lua_string {
+    my $self = shift;
+    YYY { lua_string => \@_ };
+    return;
+}
+
+sub got_lua {
+    my $self = shift;
+    YYY { lua => \@_ };
+    return;
+}
+
+sub got_value {
+    my $self = shift;
+    YYY \@_;
+    return @_;
+}
+
+#sub got_block { 
+#  +{ map ref $_ eq 'Pegex::Nginx::Data' ? $_[1]->[0]->[0] : $_, @_ }
+#}
 1;

--- a/lib/Pegex/Nginx/Grammar.pm
+++ b/lib/Pegex/Nginx/Grammar.pm
@@ -9,32 +9,156 @@ sub make_tree {   # Generated/Inlined by Pegex::Grammar (0.60)
     '+grammar' => 'nginx',
     '+toprule' => 'conf',
     '+version' => '0.0.1',
+    '_' => {
+      '.rgx' => qr/\G\s*/
+    },
     'assignment' => {
-      '.rgx' => qr/\G\s*([\w\/]+)([^\}\{;,]+)*\s*;\s*\r?\n?/
+      '.all' => [
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'key'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '+min' => 1,
+          '.ref' => 'param'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'line_ending'
+        }
+      ]
+    },
+    'blank_line' => {
+      '.rgx' => qr/\G\s*\r?\n/
     },
     'block' => {
       '.all' => [
         {
-          '.rgx' => qr/\G\s*([\w\/]+)(=|\~\*|\~|\^\~)*([^\}\{;,]+)*\s*\{\s*\r?\n?/
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'block_head'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'block_start'
+        },
+        {
+          '.ref' => '_'
         },
         {
           '+min' => 0,
           '.ref' => 'value'
         },
         {
-          '.rgx' => qr/\G\s*\s*\}\s*\r?\n?/
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'block_end'
+        },
+        {
+          '.ref' => '_'
         }
       ]
     },
+    'block_end' => {
+      '.rgx' => qr/\G\s*\}\s*\r?\n?/
+    },
+    'block_head' => {
+      '.all' => [
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'key'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '+min' => 0,
+          '.ref' => 'modifier'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '+min' => 0,
+          '.ref' => 'param'
+        },
+        {
+          '.ref' => '_'
+        }
+      ]
+    },
+    'block_start' => {
+      '.rgx' => qr/\G\s*\{\s*\r?\n?/
+    },
     'comment' => {
-      '.rgx' => qr/\G\s*\#.*\r?\n/
+      '.any' => [
+        {
+          '.rgx' => qr/\G\s*\#.*\r?\n/
+        },
+        {
+          '.ref' => 'blank_line'
+        }
+      ]
     },
     'conf' => {
       '+min' => 0,
       '.ref' => 'value'
     },
+    'key' => {
+      '.rgx' => qr/\G([\w\/]+)/
+    },
+    'line_ending' => {
+      '.rgx' => qr/\G\s*;\s*\r?\n?/
+    },
     'lua' => {
-      '.rgx' => qr/\G\s*(\w+?lua)([\s\S]+?)\s*;\s*\r?\n?/
+      '.all' => [
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'lua_word'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'lua_string'
+        },
+        {
+          '.ref' => '_'
+        },
+        {
+          '.ref' => 'line_ending'
+        },
+        {
+          '.ref' => '_'
+        }
+      ]
+    },
+    'lua_string' => {
+      '.rgx' => qr/\G(?:'((?:[^\\']|\\'|\\\\)*?)')/
+    },
+    'lua_word' => {
+      '.rgx' => qr/\G(\w*lua)/
+    },
+    'modifier' => {
+      '.rgx' => qr/\G(=|\~\*|\~|\^\~)/
+    },
+    'param' => {
+      '.rgx' => qr/\G([^\}\{;,]+)/
     },
     'value' => {
       '.any' => [
@@ -42,13 +166,13 @@ sub make_tree {   # Generated/Inlined by Pegex::Grammar (0.60)
           '.ref' => 'block'
         },
         {
-          '.ref' => 'lua'
-        },
-        {
           '.ref' => 'assignment'
         },
         {
           '.ref' => 'comment'
+        },
+        {
+          '.ref' => 'lua'
         }
       ]
     }

--- a/load.pl
+++ b/load.pl
@@ -11,5 +11,5 @@ open my $in, $infile or
     die "Cannot open $infile for reading: $!\n";
 
 my $src = do { local $/; <$in> };
-my $ast = Pegex::Nginx->new->load($src);
-print Dumper $ast;
+my $ast = Pegex::Nginx->new->load($src, debug => 0);
+#print Dumper $ast;

--- a/pgx/nginx.pgx
+++ b/pgx/nginx.pgx
@@ -3,20 +3,29 @@
 
 conf: value*
 
-value: block | lua | assignment | comment
+value: block | assignment | comment | lua
 
-block: 
-  /- block-head block-start / 
-    ( value* ) 
-  /- block-end /
-block-head: / key modifier* param* /
-lua: /- ( <WORD>+?lua ) ( ALL+? ) line-ending /
-assignment: /- key param* line-ending /
+block: - block-head - block-start - value* - block-end -
+block-head: - key - modifier* - param* -
+### this is for storing content within Single Quotes
+### You may need something similar for double quotes if necessary
+lua-string:
+    /(:
+        SINGLE
+        ((: [^ BACK SINGLE] |
+            BACK SINGLE |
+            BACK BACK
+        )*?)
+        SINGLE
+    )/
+lua-word: / ( <WORD>*lua ) /
+lua: - lua-word - lua-string - line-ending -
+assignment: - key - param+ - line-ending
 
 # CONSTANTS
 block-start: /- LCURLY - EOL?/
 block-end: /- RCURLY - EOL?/
-comment: /- HASH ANY* EOL /
+comment: /- HASH ANY* EOL / | blank-line
 blank-line: /- EOL/
 line-ending: /- SEMI - EOL?/
 key: / ( [ WORD SLASH ]+ ) /

--- a/rebuild-grammar
+++ b/rebuild-grammar
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+perl -Ilib -MPegex::Nginx::Grammar=compile


### PR DESCRIPTION
@danielamaya 

The following are the changes:
- fixed the grammar to handle embedded Lua code correctly
- fixed the receiver to demonstrate how to retrieve specific values from the config file correctly
- fixed the load.pl script to allow `debug => 0` or `debug=>1` instead of having to change `lib/Pegex/Nginx.pm` all the time.
- added a `rebuild-grammar` script to rebuild grammar on command line without bending over.
