### PR TITLE
fixing the directive parsing so that there are no trailing spaces.

### DIFF
--- a/lib/Pegex/Nginx/Data.pm
+++ b/lib/Pegex/Nginx/Data.pm
@@ -9,6 +9,18 @@ use feature qw/state say/;
 sub got_comment { return; }
 sub got_blank_line { return; }
 
+sub got_modifier {
+    my $self = shift;
+    #YYY { modifier => \@_ };
+    return @_;
+}
+
+sub got_directive {
+    my $self = shift;
+    #YYY { directive => \@_ };
+    return @_;
+}
+
 sub got_block {
     my $block = pop;
     push @{$block->[1]}, {
@@ -29,14 +41,14 @@ sub got_lua_word {
 
 sub got_lua_string {
     my $self = shift;
-    #YYY { lua_string => \@_ };
-    return;
+    #say $_[0];
+    return $_[0];
 }
 
 sub got_lua {
-    my $self = shift;
-    #YYY { lua => \@_ };
-    return;
+    my ($self, $lua) = @_;
+    $self->flatten($lua) if ref $lua eq 'ARRAY';
+    return { $lua->[0] => $lua->[1] };
 }
 
 sub got_value {

--- a/lib/Pegex/Nginx/Grammar.pm
+++ b/lib/Pegex/Nginx/Grammar.pm
@@ -93,7 +93,7 @@ sub make_tree {   # Generated/Inlined by Pegex::Grammar (0.60)
         },
         {
           '+min' => 0,
-          '.ref' => 'param'
+          '.ref' => 'directive'
         },
         {
           '.ref' => '_'
@@ -116,6 +116,9 @@ sub make_tree {   # Generated/Inlined by Pegex::Grammar (0.60)
     'conf' => {
       '+min' => 0,
       '.ref' => 'value'
+    },
+    'directive' => {
+      '.rgx' => qr/\G([^\}\{;,\s]+)/
     },
     'key' => {
       '.rgx' => qr/\G([\w\/]+)/

--- a/load.pl
+++ b/load.pl
@@ -12,3 +12,4 @@ open my $in, $infile or
 
 my $src = do { local $/; <$in> };
 my $ast = Pegex::Nginx->new->load($src, debug => 0);
+print Dumper($ast), "\n";

--- a/pgx/nginx.pgx
+++ b/pgx/nginx.pgx
@@ -6,7 +6,7 @@ conf: value*
 value: block | assignment | comment | lua
 
 block: - block-head - block-start - value* - block-end -
-block-head: - key - modifier* - param* -
+block-head: - key - modifier* - directive* -
 ### this is for storing content within Single Quotes
 ### You may need something similar for double quotes if necessary
 lua-string:
@@ -30,4 +30,5 @@ blank-line: /- EOL/
 line-ending: /- SEMI - EOL?/
 key: / ( [ WORD SLASH ]+ ) /
 modifier: / ( EQUAL | TILDE STAR | TILDE | CARET TILDE ) /
+directive: / ( [^ RCURLY LCURLY SEMI COMMA WS ]+ ) /
 param: / ( [^ RCURLY LCURLY SEMI COMMA ]+ ) /


### PR DESCRIPTION
- handling the lua portion as well for you here.
- fixing the directive parsing. the "/ " and "/404.html " will not have trailing spaces with a better grammar rule.
